### PR TITLE
Fix code scanning alert no. 4: Useless regular-expression character escape

### DIFF
--- a/test/resource-types/text.js
+++ b/test/resource-types/text.js
@@ -56,7 +56,7 @@ describe('text', function() {
         path: 'somefile.txt',
         type: 'text',
         params: {
-          regex: '(\\d+)\\.(\\d+)\\.(\\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'
+          regex: '(\\d+).(\\d+).(\\d+)(?:-([0-9A-Za-z-]+(?:.[0-9A-Za-z-]+)*))?'
         }
       };
       this.mockFs.expects('readFileSync').once().withExactArgs('somefile.txt', 'UTF-8').returns(' version1 = "0.0.0", version2 = "1.1.1-beta" ');
@@ -75,7 +75,7 @@ describe('text', function() {
         path: 'somefile.txt',
         type: 'text',
         params: {
-          regex: '(\\d+)\\.(\\d+)\\.(\\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'
+          regex: '(\\d+).(\\d+).(\\d+)(?:-([0-9A-Za-z-]+(?:.[0-9A-Za-z-]+)*))?'
         }
       };
       this.mockFs.expects('readFile').once().withExactArgs('somefile.txt', 'UTF-8', sinon.match.func).callsArgWith(2, null, ' version = "0.0.0" ');
@@ -91,7 +91,7 @@ describe('text', function() {
         path: 'somefile.txt',
         type: 'text',
         params: {
-          regex: '(\\d+)\\.(\\d+)\\.(\\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'
+          regex: '(\\d+).(\\d+).(\\d+)(?:-([0-9A-Za-z-]+(?:.[0-9A-Za-z-]+)*))?'
         }
       };
       this.mockFs.expects('readFile').once().withExactArgs('somefile.txt', 'UTF-8', sinon.match.func).callsArgWith(2, null, ' version = "9.8.7" \n side_version = "1.2.3" ');
@@ -107,7 +107,7 @@ describe('text', function() {
         path: 'somefile.txt',
         type: 'text',
         params: {
-          regex: '(\\d+)\\.(\\d+)\\.(\\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'
+          regex: '(\\d+).(\\d+).(\\d+)(?:-([0-9A-Za-z-]+(?:.[0-9A-Za-z-]+)*))?'
         }
       };
       this.mockFs.expects('readFile').once().withExactArgs('somefile.txt', 'UTF-8', sinon.match.func).callsArgWith(2, null, ' version = "1.1.1-pre.2" ');


### PR DESCRIPTION
Fixes [https://github.com/cliffano/rtk/security/code-scanning/4](https://github.com/cliffano/rtk/security/code-scanning/4)

To fix the problem, we need to remove the unnecessary backslashes from the regular expression string literals. This will ensure that the regular expression is correctly interpreted and that the code adheres to best practices. Specifically, we need to update the regular expression on lines 59, 78, 94, and 110 to remove the backslashes before the dot characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
